### PR TITLE
BUGFIX: Fix script compilation errors

### DIFF
--- a/Classes/Driver/Version1/IndexerDriver.php
+++ b/Classes/Driver/Version1/IndexerDriver.php
@@ -49,14 +49,20 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
                     ]
                 ],
                 // http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.7/docs-update.html
-                'script' => [
-                    'script_id' => 'updateFulltextParts',
-                    'lang' => 'groovy',
+                [
+                    'script' => '
+                            fulltext = (ctx._source.containsKey("__fulltext") ? ctx._source.__fulltext : new LinkedHashMap());
+                            fulltextParts = (ctx._source.containsKey("__fulltextParts") ? ctx._source.__fulltextParts : new LinkedHashMap());
+                            ctx._source = newData;
+                            ctx._source.__fulltext = fulltext;
+                            ctx._source.__fulltextParts = fulltextParts
+                            ',
                     'params' => [
                         'newData' => $documentData
-                    ]
-                ],
-                'upsert' => $documentData
+                    ],
+                    'upsert' => $documentData,
+                    'lang' => 'groovy'
+                ]
             ];
         } else {
             // non-fulltext-root documents can be indexed as-they-are
@@ -112,22 +118,52 @@ class IndexerDriver extends AbstractIndexerDriver implements IndexerDriverInterf
                 ]
             ],
             // http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-update.html
-            // first, update the __fulltextParts, then re-generate the __fulltext from all __fulltextParts
-            'script' => [
-                'script_id' => 'regenerateFulltext',
-                'lang' => 'groovy',
+            [
+                // first, update the __fulltextParts, then re-generate the __fulltext from all __fulltextParts
+                'script' => '
+                    if (!(ctx._source.containsKey("__fulltextParts") && ctx._source.__fulltextParts instanceof Map)) {
+                        ctx._source.__fulltextParts = new LinkedHashMap();
+                    }
+
+                    if (nodeIsRemoved || nodeIsHidden || fulltext.size() == 0) {
+                        if (ctx._source.__fulltextParts.containsKey(identifier)) {
+                            ctx._source.__fulltextParts.remove(identifier);
+                        }
+                    } else {
+                        ctx._source.__fulltextParts[identifier] = fulltext;
+                    }
+                    ctx._source.__fulltext = new LinkedHashMap();
+
+                    Iterator<LinkedHashMap.Entry<String, LinkedHashMap>> fulltextByNode = ctx._source.__fulltextParts.entrySet().iterator();
+                    for (fulltextByNode; fulltextByNode.hasNext();) {
+                        Iterator<LinkedHashMap.Entry<String, String>> elementIterator = fulltextByNode.next().getValue().entrySet().iterator();
+                        for (elementIterator; elementIterator.hasNext();) {
+                            Map.Entry<String, String> element = elementIterator.next();
+                            String value;
+
+                            if (ctx._source.__fulltext.containsKey(element.key)) {
+                                value = ctx._source.__fulltext[element.key] + " " + element.value.trim();
+                            } else {
+                                value = element.value.trim();
+                            }
+
+                            ctx._source.__fulltext[element.key] = value;
+                        }
+                    }
+                ',
                 'params' => [
                     'identifier' => $node->getIdentifier(),
                     'nodeIsRemoved' => $node->isRemoved(),
                     'nodeIsHidden' => $node->isHidden(),
                     'fulltext' => $fulltextIndexOfNode
                 ],
-            ],
-            'upsert' => [
-                '__fulltext' => $fulltextIndexOfNode,
-                '__fulltextParts' => [
-                    $node->getIdentifier() => $fulltextIndexOfNode
-                ]
+                'upsert' => [
+                    '__fulltext' => $fulltextIndexOfNode,
+                    '__fulltextParts' => [
+                        $node->getIdentifier() => $fulltextIndexOfNode
+                    ]
+                ],
+                'lang' => 'groovy'
             ]
         ];
     }

--- a/Classes/Driver/Version1/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version1/Mapping/NodeTypeMappingBuilder.php
@@ -12,7 +12,6 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version1\Mappin
  */
 
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\AbstractNodeTypeMappingBuilder;
-use Flowpack\ElasticSearch\ContentRepositoryAdaptor\ElasticSearchClient;
 use Flowpack\ElasticSearch\Domain\Model\Index;
 use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use Flowpack\ElasticSearch\Mapping\MappingCollection;
@@ -29,12 +28,6 @@ use TYPO3\TYPO3CR\Domain\Model\NodeType;
 class NodeTypeMappingBuilder extends AbstractNodeTypeMappingBuilder
 {
     /**
-     * @Flow\Inject
-     * @var ElasticSearchClient
-     */
-    protected $client;
-
-    /**
      * Builds a Mapping Collection from the configured node types
      *
      * @param Index $index
@@ -45,8 +38,6 @@ class NodeTypeMappingBuilder extends AbstractNodeTypeMappingBuilder
         $this->lastMappingErrors = new Result();
 
         $mappings = new MappingCollection(MappingCollection::TYPE_ENTITY);
-
-        $this->setupStoredScripts($index);
 
         /** @var NodeType $nodeType */
         foreach ($this->nodeTypeManager->getNodeTypes() as $nodeTypeName => $nodeType) {
@@ -94,59 +85,5 @@ class NodeTypeMappingBuilder extends AbstractNodeTypeMappingBuilder
         }
 
         return $mappings;
-    }
-
-    /**
-     * Store scripts used during indexing in Elasticsearch.
-     *
-     * @param Index $index
-     * @return void
-     */
-    protected function setupStoredScripts(Index $index)
-    {
-        $this->client->request(
-            'POST',
-            '/_scripts/groovy/updateFulltextParts',
-            [],
-            json_encode(['script' => '
-                    fulltext = (ctx._source.containsKey("__fulltext") ? ctx._source.__fulltext : new HashMap());
-                    fulltextParts = (ctx._source.containsKey("__fulltextParts") ? ctx._source.__fulltextParts : new HashMap());
-                    ctx._source = newData;
-                    ctx._source.__fulltext = fulltext;
-                    ctx._source.__fulltextParts = fulltextParts'
-            ])
-        );
-
-        $this->client->request(
-            'POST',
-            '/_scripts/groovy/regenerateFulltext',
-            [],
-            json_encode(['script' => '
-                ctx._source.__fulltext = new HashMap();
-                if (!ctx._source.containsKey("__fulltextParts")) {
-                    ctx._source.__fulltextParts = new HashMap();
-                }
-                
-                if (nodeIsRemoved || nodeIsHidden || fulltext.size() == 0) {
-                    if (ctx._source.__fulltextParts.containsKey(identifier)) {
-                        ctx._source.__fulltextParts.remove(identifier);
-                    }
-                } else {
-                    ctx._source.__fulltextParts.put(identifier, fulltext);
-                }
-
-                ctx._source.__fulltextParts.each {
-                    originNodeIdentifier, partContent -> partContent.each {
-                        bucketKey, content ->
-                            if (ctx._source.__fulltext.containsKey(bucketKey)) {
-                                value = ctx._source.__fulltext[bucketKey] + " " + content.trim();
-                            } else {
-                                value = content.trim();
-                            }
-                            ctx._source.__fulltext[bucketKey] = value;
-                    }
-                }'
-            ])
-        );
     }
 }

--- a/Classes/Driver/Version2/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version2/Mapping/NodeTypeMappingBuilder.php
@@ -11,9 +11,8 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version2\Mappin
  * source code.
  */
 
-use Flowpack\ElasticSearch\Domain\Model\Index;
-use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version1;
 use TYPO3\Flow\Annotations as Flow;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version1;
 
 /**
  * NodeTypeMappingBuilder for Elasticsearch version 2.x
@@ -22,59 +21,4 @@ use TYPO3\Flow\Annotations as Flow;
  */
 class NodeTypeMappingBuilder extends Version1\Mapping\NodeTypeMappingBuilder
 {
-    /**
-     * Store scripts used during indexing in Elasticsearch.
-     *
-     * @param Index $index
-     * @return void
-     */
-    protected function setupStoredScripts(Index $index)
-    {
-        $this->client->request(
-            'POST',
-            '/_scripts/groovy/updateFulltextParts',
-            [],
-            json_encode(['script' => '
-                fulltext = (ctx._source.containsKey("__fulltext") ? ctx._source.__fulltext : new HashMap());
-                fulltextParts = (ctx._source.containsKey("__fulltextParts") ? ctx._source.__fulltextParts : new HashMap());
-                
-                ctx._source = newData;
-                ctx._source.__fulltext = fulltext;
-                ctx._source.__fulltextParts = fulltextParts'
-            ])
-        );
-
-        $this->client->request(
-            'POST',
-            '/_scripts/groovy/regenerateFulltext',
-            [],
-            json_encode(['script' => '
-                ctx._source.__fulltext = new HashMap();
-
-                if (!(ctx._source.containsKey("__fulltextParts") && ctx._source.__fulltextParts instanceof Map)) {
-                    ctx._source.__fulltextParts = new HashMap();
-                }
-
-                if (nodeIsRemoved || nodeIsHidden || fulltext.size() == 0) {
-                    if (ctx._source.__fulltextParts.containsKey(identifier)) {
-                        ctx._source.__fulltextParts.remove(identifier);
-                    }
-                } else {
-                    ctx._source.__fulltextParts.put(identifier, fulltext);
-                }
-
-                ctx._source.__fulltextParts.each {
-                    originNodeIdentifier, partContent -> partContent.each {
-                        bucketKey, content ->
-                            if (ctx._source.__fulltext.containsKey(bucketKey)) {
-                                value = ctx._source.__fulltext[bucketKey] + " " + content.trim();
-                            } else {
-                                value = content.trim();
-                            }
-                            ctx._source.__fulltext[bucketKey] = value;
-                    }
-                }'
-            ])
-        );
-    }
 }

--- a/Classes/Driver/Version5/IndexerDriver.php
+++ b/Classes/Driver/Version5/IndexerDriver.php
@@ -42,10 +42,16 @@ class IndexerDriver extends Version2\IndexerDriver
                         '_retry_on_conflict' => 3
                     ]
                 ],
-                // http://www.elasticsearch.org/guide/en/elasticsearch/reference/2.4/docs-update.html
+                // http://www.elasticsearch.org/guide/en/elasticsearch/reference/5.0/docs-update.html
                 [
                     'script' => [
-                        'stored' => 'updateFulltextParts',
+                        'lang' => 'painless',
+                        'inline' => '
+                            HashMap fulltext = (ctx._source.containsKey("__fulltext") ? ctx._source.__fulltext : new HashMap());
+                            HashMap fulltextParts = (ctx._source.containsKey("__fulltextParts") ? ctx._source.__fulltextParts : new HashMap());
+                            ctx._source = params.newData;
+                            ctx._source.__fulltext = fulltext;
+                            ctx._source.__fulltextParts = fulltextParts',
                         'params' => [
                             'newData' => $documentData
                         ]
@@ -114,7 +120,32 @@ class IndexerDriver extends Version2\IndexerDriver
             [
                 // first, update the __fulltextParts, then re-generate the __fulltext from all __fulltextParts
                 'script' => [
-                    'stored' => 'regenerateFulltext',
+                    'lang' => 'painless',
+                    'inline' => '
+                        ctx._source.__fulltext = new HashMap();
+                        if (!ctx._source.containsKey("__fulltextParts")) {
+                            ctx._source.__fulltextParts = new HashMap();
+                        }
+                        
+                        if (params.nodeIsRemoved || params.nodeIsHidden || params.fulltext.size() == 0) {
+                            if (ctx._source.__fulltextParts.containsKey(params.identifier)) {
+                                ctx._source.__fulltextParts.remove(params.identifier);
+                            }
+                        } else {
+                            ctx._source.__fulltextParts.put(params.identifier, params.fulltext);
+                        }
+    
+                        ctx._source.__fulltextParts.each {
+                            originNodeIdentifier, partContent -> partContent.each {
+                                bucketKey, content ->
+                                    if (ctx._source.__fulltext.containsKey(bucketKey)) {
+                                        value = ctx._source.__fulltext[bucketKey] + " " + content.trim();
+                                    } else {
+                                        value = content.trim();
+                                    }
+                                    ctx._source.__fulltext[bucketKey] = value;
+                            }
+                        }',
                     'params' => [
                         'identifier' => $node->getIdentifier(),
                         'nodeIsRemoved' => $node->isRemoved(),

--- a/Classes/Driver/Version5/IndexerDriver.php
+++ b/Classes/Driver/Version5/IndexerDriver.php
@@ -126,7 +126,7 @@ class IndexerDriver extends Version2\IndexerDriver
                         if (!ctx._source.containsKey("__fulltextParts")) {
                             ctx._source.__fulltextParts = new HashMap();
                         }
-                        
+
                         if (params.nodeIsRemoved || params.nodeIsHidden || params.fulltext.size() == 0) {
                             if (ctx._source.__fulltextParts.containsKey(params.identifier)) {
                                 ctx._source.__fulltextParts.remove(params.identifier);
@@ -134,16 +134,16 @@ class IndexerDriver extends Version2\IndexerDriver
                         } else {
                             ctx._source.__fulltextParts.put(params.identifier, params.fulltext);
                         }
-    
-                        ctx._source.__fulltextParts.each {
-                            originNodeIdentifier, partContent -> partContent.each {
-                                bucketKey, content ->
-                                    if (ctx._source.__fulltext.containsKey(bucketKey)) {
-                                        value = ctx._source.__fulltext[bucketKey] + " " + content.trim();
-                                    } else {
-                                        value = content.trim();
-                                    }
-                                    ctx._source.__fulltext[bucketKey] = value;
+
+                        for (fulltextPart in ctx._source.__fulltextParts.entrySet()) {
+                            for (entry in fulltextPart.getValue().entrySet()) {
+                                def value = "";
+                                if (ctx._source.__fulltext.containsKey(entry.getKey())) {
+                                    value = ctx._source.__fulltext[entry.getKey()] + " " + entry.getValue().trim();
+                                } else {
+                                    value = entry.getValue().trim();
+                                }
+                                ctx._source.__fulltext[entry.getKey()] = value;
                             }
                         }',
                     'params' => [

--- a/Classes/Driver/Version5/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version5/Mapping/NodeTypeMappingBuilder.php
@@ -73,7 +73,7 @@ class NodeTypeMappingBuilder extends Version2\Mapping\NodeTypeMappingBuilder
                 'path_match' => '__dimensionCombinations.*',
                 'match_mapping_type' => 'string',
                 'mapping' => [
-                    'type' => 'keyword'
+                    'type' => 'text'
                 ]
             ]);
             $mapping->setPropertyByPath('__dimensionCombinationHash', [

--- a/Classes/Driver/Version5/Mapping/NodeTypeMappingBuilder.php
+++ b/Classes/Driver/Version5/Mapping/NodeTypeMappingBuilder.php
@@ -53,8 +53,6 @@ class NodeTypeMappingBuilder extends Version2\Mapping\NodeTypeMappingBuilder
 
         $mappings = new MappingCollection(MappingCollection::TYPE_ENTITY);
 
-        $this->setupStoredScripts($index);
-
         /** @var NodeType $nodeType */
         foreach ($this->nodeTypeManager->getNodeTypes() as $nodeTypeName => $nodeType) {
             if ($nodeTypeName === 'unstructured' || $nodeType->isAbstract()) {
@@ -102,67 +100,6 @@ class NodeTypeMappingBuilder extends Version2\Mapping\NodeTypeMappingBuilder
         }
 
         return $mappings;
-    }
-
-    /**
-     * Store scripts used during indexing in Elasticsearch.
-     *
-     * @param Index $index
-     * @return void
-     */
-    protected function setupStoredScripts(Index $index)
-    {
-        $this->client->request(
-            'POST',
-            '/_scripts/updateFulltextParts',
-            [],
-            json_encode(['script' => [
-                'lang' => 'painless',
-                'code' => '
-                    HashMap fulltext = (ctx._source.containsKey("__fulltext") ? ctx._source.__fulltext : new HashMap());
-                    HashMap fulltextParts = (ctx._source.containsKey("__fulltextParts") ? ctx._source.__fulltextParts : new HashMap());
-                    ctx._source = params.newData;
-                    ctx._source.__fulltext = fulltext;
-                    ctx._source.__fulltextParts = fulltextParts'
-                ]
-            ])
-        );
-
-        $this->client->request(
-            'POST',
-            '/_scripts/regenerateFulltext',
-            [],
-            json_encode(['script' => [
-                'lang' => 'painless',
-                'code' => '
-                        ctx._source.__fulltext = new HashMap();
-                        if (!ctx._source.containsKey("__fulltextParts")) {
-                            ctx._source.__fulltextParts = new HashMap();
-                        }
-                        
-                        if (params.nodeIsRemoved || params.nodeIsHidden || params.fulltext.size() == 0) {
-                            if (ctx._source.__fulltextParts.containsKey(params.identifier)) {
-                                ctx._source.__fulltextParts.remove(params.identifier);
-                            }
-                        } else {
-                            ctx._source.__fulltextParts.put(params.identifier, params.fulltext);
-                        }
-    
-                        ctx._source.__fulltextParts.each {
-                            originNodeIdentifier, partContent -> partContent.each {
-                                bucketKey, content ->
-                                    if (ctx._source.__fulltext.containsKey(bucketKey)) {
-                                        value = ctx._source.__fulltext[bucketKey] + " " + content.trim();
-                                    } else {
-                                        value = content.trim();
-                                    }
-                                    ctx._source.__fulltext[bucketKey] = value;
-                            }
-                        }
-                        '
-                ]
-            ])
-        );
     }
 
     /**

--- a/Documentation/ElasticConfiguration-2.x.md
+++ b/Documentation/ElasticConfiguration-2.x.md
@@ -6,7 +6,6 @@ Since version 2.0 the fine-grained script settings are in place as described in 
 ```
 # The following settings are absolutely required for the CR adaptor to work
 script.inline: true
-script.indexed: true
 
 # the following settings secure your cluster
 cluster.name: [PUT_YOUR_CUSTOM_NAME_HERE]


### PR DESCRIPTION
This moves scripts to inline again since stored scripts are not supported on AWS.
ElasticSearch will only compile the script once and keep a cached version which
will get executed instead of recompiling it, so this should not impact performance
too much.

This also fixes the type conflict of `__dimensionCombinations.language` by changing
the mapping type to `text`.