### PR TITLE
TASK: Adjust search to changes in Elasticsearch 5

### DIFF
--- a/Classes/Driver/Version5/Query/FilteredQuery.php
+++ b/Classes/Driver/Version5/Query/FilteredQuery.php
@@ -12,10 +12,37 @@ namespace Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version5\Query;
  */
 
 use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version1;
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception;
 
 /**
  * Default Filtered Query
  */
 class FilteredQuery extends Version1\Query\FilteredQuery
 {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function fulltext($searchWord)
+    {
+        $this->appendAtPath('query.bool.must', [
+            'query_string' => [
+                'query' => $searchWord
+            ]
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function queryFilter($filterType, $filterOptions, $clauseType = 'must')
+    {
+        if (!in_array($clauseType, ['must', 'should', 'must_not'])) {
+            throw new Exception\QueryBuildingException('The given clause type "' . $clauseType . '" is not supported. Must be one of "must", "should", "must_not".',
+                1383716082);
+        }
+
+        $this->appendAtPath('query.bool.filter.bool.' . $clauseType, [$filterType => $filterOptions]);
+    }
+
 }

--- a/Classes/Eel/ElasticSearchQueryBuilder.php
+++ b/Classes/Eel/ElasticSearchQueryBuilder.php
@@ -728,7 +728,10 @@ class ElasticSearchQueryBuilder implements QueryBuilderInterface, ProtectedConte
          * we might be able to use https://github.com/elasticsearch/elasticsearch/issues/3300 as soon as it is merged.
          */
         foreach ($hits['hits'] as $hit) {
-            $nodePath = current($hit['fields']['__path']);
+            $nodePath = $hit[isset($hit['fields']) ? 'fields' : '_source']['__path'];
+            if (is_array($nodePath)) {
+                $nodePath = current($nodePath);
+            }
             $node = $this->contextNode->getNode($nodePath);
             if ($node instanceof NodeInterface && !isset($nodes[$node->getIdentifier()])) {
                 $nodes[$node->getIdentifier()] = $node;

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -79,9 +79,35 @@ Flowpack:
               className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version5\Query\FilteredQuery'
               arguments:
                 request:
-                  <<: *request_version1
+                  query:
+                    bool:
+                      must:
+                      - match_all:
+                          boost: 1.0 # force match_all to be an object
+                      filter:
+                        bool:
+                          must: []
+                          should: []
+                          must_not:
+                          - term:
+                              _hidden: true
+                          - range:
+                              _hiddenBeforeDateTime:
+                                gt: now
+                          - range:
+                              _hiddenAfterDateTime:
+                                lt: now
+                  _source:
+                    - '__path'
                 unsupportedFieldsInCountRequest:
-                  <<: *unsupportedFieldsInCountRequest_version1
+                  - '_source'
+                  - 'sort'
+                  - 'from'
+                  - 'size'
+                  - 'highlight'
+                  - 'aggs'
+                  - 'aggregations'
+                  - 'suggest'
             document:
               className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Driver\Version5\DocumentDriver'
             indexer:


### PR DESCRIPTION
With Elasticsearch 5, some change to the search and query DSLs have been
done. In particular the removal of `filtered` queries and the `fields` parameter
affect the adaptor code (see https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_search_changes.html for details.)

This adjusts the code as needed.